### PR TITLE
Add sad path for api/v1/foods when no foods are seeded

### DIFF
--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -46,3 +46,18 @@ describe('API Routes', () => {
     done();
   });
 });
+
+describe('API routes without seeds', () => {
+  it('ge api/v1/foods returns empty array if no foods seeded',done=>{
+    chai.request(server)
+    .get('api/v1/foods') //sad path because not seeded
+    .end((err,reponse) => {
+      response.should.have.status(200);
+      response.body.should.be.a('array');
+      response.body[0].should.not.have.property('id')
+      response.body[0].should.not.have.property('name')
+      response.body[0].should.not.have.property('calories')
+    });
+    done();
+  });
+})


### PR DESCRIPTION
Closes: #2 
What does this PR do? Added a sad path for get api/v1/foods to check that if there are no foods in the database, that the api returns an empty array without any headers.
Where should the reviewer start? test/routes.spec.js